### PR TITLE
animepahe tld changes and / fix

### DIFF
--- a/helper/kwik.js
+++ b/helper/kwik.js
@@ -5,7 +5,7 @@ import axios from 'axios';
 export const extractSource = async (kwikUrl) => {
     const { data } = await axios.get(kwikUrl, {
         headers: {
-            referer: "https://animepahe.com/"
+            referer: "https://animepahe.ru/"
         }
     });
     const x = data.match(/p\}.*kwik.*/g)

--- a/scraper/animepahe/animepahe.js
+++ b/scraper/animepahe/animepahe.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { load } from 'cheerio';
 
-const animepaheBase = `https://animepahe.ru/`;
+const animepaheBase = `https://animepahe.ru`;
 const animepaheApi = `https://animepahe.ru/api`;
 const USER_AGENT = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36`;
 import { extractSource } from '../../helper/kwik.js';

--- a/scraper/animepahe/animepahe.js
+++ b/scraper/animepahe/animepahe.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import { load } from 'cheerio';
 
-const animepaheBase = `https://animepahe.com/`;
-const animepaheApi = `https://animepahe.com/api`;
+const animepaheBase = `https://animepahe.ru/`;
+const animepaheApi = `https://animepahe.ru/api`;
 const USER_AGENT = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36`;
 import { extractSource } from '../../helper/kwik.js';
 


### PR DESCRIPTION
as animepahe.com is not available from some location giving "ERR_CONNECTION_RESET" in browser and "ERR_BAD_RESPONSE" in deployed api, eg https://animeapi.cyclic.app/animepahe/info/c92b9ee7-b740-dbb1-990b-c98324471c71 changing the tld to .ru, also removed unnecessary / in url